### PR TITLE
Fixes variants support

### DIFF
--- a/src/Avalonia/Superheater.Avalonia.Core/UserControls/EditorFields.axaml
+++ b/src/Avalonia/Superheater.Avalonia.Core/UserControls/EditorFields.axaml
@@ -14,6 +14,7 @@
             <RowDefinition Height="auto"></RowDefinition>
             <RowDefinition Height="auto"></RowDefinition>
             <RowDefinition Height="auto"></RowDefinition>
+            <RowDefinition Height="auto"></RowDefinition>
             <RowDefinition Height="*"></RowDefinition>
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
@@ -59,25 +60,31 @@
                  IsReadOnly="{Binding !IsEditingAvailable}"
                  Margin="0,3"/>
 
+        <TextBox Text="{Binding FixVariants, Mode=TwoWay}"
+                 Watermark="Variants"
+                 Grid.Row="4"
+                 IsReadOnly="{Binding !IsEditingAvailable}"
+                 Margin="0,3"/>
+
         <TextBox Text="{Binding SelectedFix.ConfigFile, Mode=TwoWay}"
                  Watermark="Config file"
-                 Grid.Row="4"
+                 Grid.Row="5"
                  IsReadOnly="{Binding !IsEditingAvailable}"
                  Margin="0,3"/>
 
         <TextBox Text="{Binding SelectedFix.FilesToDelete, Mode=TwoWay}"
                  Watermark="Files to delete"
-                 Grid.Row="5"
+                 Grid.Row="6"
                  IsReadOnly="{Binding !IsEditingAvailable}"
                  Margin="0,3"/>
 
         <TextBox Text="{Binding SelectedFix.RunAfterInstall, Mode=TwoWay}"
                  Watermark="Run after install"
-                 Grid.Row="6"
+                 Grid.Row="7"
                  IsReadOnly="{Binding !IsEditingAvailable}"
                  Margin="0,3"/>
 
-        <Grid Grid.Row="7"
+        <Grid Grid.Row="8"
               Grid.Column="1"
               Margin="0,3"
               MinHeight="60">

--- a/src/Avalonia/Superheater.Avalonia.Core/UserControls/MainLists.axaml
+++ b/src/Avalonia/Superheater.Avalonia.Core/UserControls/MainLists.axaml
@@ -129,14 +129,10 @@
 
         </ListBox>
 
-        <Grid Grid.Column="2">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="*"/>
-                <RowDefinition Height="auto"/>
-            </Grid.RowDefinitions>
+        <Grid Grid.Column="2" RowDefinitions="*,auto,auto">
 
             <ScrollViewer Grid.Row="0">
-                <StackPanel Orientation="Vertical" Name="stack"></StackPanel>
+                <StackPanel Orientation="Vertical" Name="DescriptionBox"></StackPanel>
             </ScrollViewer>
 
             <TextBlock Text="{Binding Requirements, Mode=OneWay}"
@@ -144,6 +140,27 @@
                        Margin="0,2,0,0"
                        Grid.Row="1"
                        Padding="3"/>
+
+            <Grid ColumnDefinitions="auto,*"
+                  Grid.Row="2"
+                  Margin="0,2,0,0"
+                  IsVisible="{Binding FixHasVariants}">
+
+                <TextBlock Grid.Column="0"
+                           VerticalAlignment="Center"
+                           Margin="0,0,2,0">
+                    Variants:
+                </TextBlock>
+
+                <ComboBox Grid.Column="1"
+                          HorizontalAlignment="Stretch"
+                          Margin="0,2,0,0"
+                          ItemsSource="{Binding FixVariants}"
+                          SelectedItem="{Binding SelectedFixVariant}"/>
+
+            </Grid>
+
+
         </Grid>
 
     </Grid>

--- a/src/Avalonia/Superheater.Avalonia.Core/UserControls/MainLists.axaml
+++ b/src/Avalonia/Superheater.Avalonia.Core/UserControls/MainLists.axaml
@@ -149,7 +149,7 @@
                 <TextBlock Grid.Column="0"
                            VerticalAlignment="Center"
                            Margin="0,0,2,0">
-                    Variants:
+                    Variant:
                 </TextBlock>
 
                 <ComboBox Grid.Column="1"

--- a/src/Avalonia/Superheater.Avalonia.Core/UserControls/MainLists.axaml.cs
+++ b/src/Avalonia/Superheater.Avalonia.Core/UserControls/MainLists.axaml.cs
@@ -19,7 +19,7 @@ namespace SteamFDA.UserControls
         {
             var style = Application.Current.Resources.TryGetValue("ResourceKey", out var value);
 
-            stack.Children.Clear();
+            DescriptionBox.Children.Clear();
 
             if (((ListBox)sender).SelectedItem is null)
             {
@@ -35,7 +35,7 @@ namespace SteamFDA.UserControls
                 if (item.StartsWith("*") && item.EndsWith("*"))
                 {
                     var text = item[1..^1];
-                    stack.Children.Add(new TextBlock() { Text = text, FontWeight = FontWeight.Bold, TextWrapping = TextWrapping.Wrap });
+                    DescriptionBox.Children.Add(new TextBlock() { Text = text, FontWeight = FontWeight.Bold, TextWrapping = TextWrapping.Wrap });
 
                     continue;
                 }
@@ -48,12 +48,12 @@ namespace SteamFDA.UserControls
 
                     button.Click += UrlButtonClick;
 
-                    stack.Children.Add(button);
+                    DescriptionBox.Children.Add(button);
 
                     continue;
                 }
 
-                stack.Children.Add(new TextBlock() { Text = item, TextWrapping = TextWrapping.Wrap });
+                DescriptionBox.Children.Add(new TextBlock() { Text = item, TextWrapping = TextWrapping.Wrap });
             }
         }
 

--- a/src/Avalonia/Superheater.Avalonia.Core/ViewModels/EditorViewModel.cs
+++ b/src/Avalonia/Superheater.Avalonia.Core/ViewModels/EditorViewModel.cs
@@ -30,6 +30,12 @@ namespace SteamFDA.ViewModels
 
         public ObservableCollection<GameEntity> AvailableGamesList { get; set; }
 
+        public string FixVariants
+        {
+            get => SelectedFix?.Variants is null ? string.Empty : string.Join(";", SelectedFix.Variants);
+            set => SelectedFix.Variants = value.Split(";").ToList();
+        }
+
         public int SelectedFixIndex { get; set; } = -1;
 
         public bool IsEditingAvailable => SelectedFix is not null;
@@ -82,6 +88,7 @@ namespace SteamFDA.ViewModels
         [NotifyPropertyChangedFor(nameof(Name))]
         [NotifyPropertyChangedFor(nameof(Version))]
         [NotifyPropertyChangedFor(nameof(Url))]
+        [NotifyPropertyChangedFor(nameof(FixVariants))]
         [NotifyCanExecuteChangedFor(nameof(RemoveFixCommand))]
         [NotifyCanExecuteChangedFor(nameof(MoveFixDownCommand))]
         [NotifyCanExecuteChangedFor(nameof(MoveFixUpCommand))]

--- a/src/Avalonia/Superheater.Avalonia.Core/ViewModels/MainViewModel.cs
+++ b/src/Avalonia/Superheater.Avalonia.Core/ViewModels/MainViewModel.cs
@@ -208,7 +208,7 @@ namespace SteamFDA.ViewModels
 
             FileTools.Progress.ProgressChanged += Progress_ProgressChanged;
 
-            var result = await _mainModel.InstallFix(SelectedGame.Game, SelectedFix);
+            var result = await _mainModel.InstallFix(SelectedGame.Game, SelectedFix, SelectedFixVariant);
 
             FillGamesList();
 
@@ -313,7 +313,7 @@ namespace SteamFDA.ViewModels
 
             var selectedFix = SelectedFix;
 
-            var result = await _mainModel.UpdateFix(SelectedGame.Game, SelectedFix);
+            var result = await _mainModel.UpdateFix(SelectedGame.Game, SelectedFix, SelectedFixVariant);
 
             FillGamesList();
 

--- a/src/Avalonia/Superheater.Avalonia.Core/ViewModels/MainViewModel.cs
+++ b/src/Avalonia/Superheater.Avalonia.Core/ViewModels/MainViewModel.cs
@@ -40,6 +40,23 @@ namespace SteamFDA.ViewModels
         public List<FixEntity>? SelectedGameFixesList => SelectedGame?.FixesList.Fixes.ToList();
 
         /// <summary>
+        /// List of selected fix's variants
+        /// </summary>
+        public List<string>? FixVariants => SelectedFix?.Variants;
+
+        /// <summary>
+        /// Selected fix variant
+        /// </summary>
+        [ObservableProperty]
+        [NotifyCanExecuteChangedFor(nameof(InstallFixCommand))]
+        private string? _selectedFixVariant;
+
+        /// <summary>
+        /// Does selected fix has variants
+        /// </summary>
+        public bool FixHasVariants => FixVariants is not null && FixVariants.Any();
+
+        /// <summary>
         /// Does selected fix has any updates
         /// </summary>
         public bool SelectedFixHasUpdate => SelectedFix?.HasNewerVersion ?? false;
@@ -55,6 +72,8 @@ namespace SteamFDA.ViewModels
         [ObservableProperty]
         [NotifyPropertyChangedFor(nameof(Requirements))]
         [NotifyPropertyChangedFor(nameof(SelectedFixHasUpdate))]
+        [NotifyPropertyChangedFor(nameof(FixVariants))]
+        [NotifyPropertyChangedFor(nameof(FixHasVariants))]
         [NotifyCanExecuteChangedFor(nameof(InstallFixCommand))]
         [NotifyCanExecuteChangedFor(nameof(UninstallFixCommand))]
         [NotifyCanExecuteChangedFor(nameof(OpenConfigCommand))]
@@ -217,7 +236,7 @@ namespace SteamFDA.ViewModels
         }
         private bool InstallFixCanExecute()
         {
-            if (SelectedFix is null || SelectedFix.IsInstalled || (SelectedGame is not null && !SelectedGame.IsGameInstalled) || _lockButtons)
+            if (SelectedFix is null || SelectedFix.IsInstalled || (SelectedGame is not null && !SelectedGame.IsGameInstalled) || FixHasVariants && SelectedFixVariant is null ||_lockButtons)
             {
                 return false;
             }

--- a/src/Common/Entities/FixEntity.cs
+++ b/src/Common/Entities/FixEntity.cs
@@ -83,6 +83,12 @@ namespace SteamFDCommon.Entities
         public string Description { get; set; }
 
         /// <summary>
+        /// List of fix's variants
+        /// Names of folders in inside a fix's archive, separated by ;
+        /// </summary>
+        public List<string>? Variants { get; set; }
+
+        /// <summary>
         /// Folder to unpack ZIP
         /// Relative to the game folder
         /// </summary>

--- a/src/Common/Entities/GameEntity.cs
+++ b/src/Common/Entities/GameEntity.cs
@@ -45,7 +45,7 @@ namespace SteamFDCommon.Entities
                     return false;
                 }
 
-                var data = Registry.GetValue(Consts.AdminRegistryKey, $"{InstallDir}\\{GameExecutable}", null);
+                var data = Registry.GetValue(Consts.AdminRegistryKey, $"{InstallDir}{GameExecutable}", null);
 
                 if (data is not null &&
                     data.Equals("~ RUNASADMIN"))
@@ -73,7 +73,7 @@ namespace SteamFDCommon.Entities
         /// </summary>
         public void SetRunAsAdmin()
         {
-            Registry.SetValue(Consts.AdminRegistryKey, $"{InstallDir}\\{GameExecutable}", "~ RUNASADMIN");
+            Registry.SetValue(Consts.AdminRegistryKey, $"{InstallDir}{GameExecutable}", "~ RUNASADMIN");
             OnPropertyChanged(nameof(DoesRequireAdmin));
         }
 

--- a/src/Common/FileTools.cs
+++ b/src/Common/FileTools.cs
@@ -59,24 +59,38 @@ namespace SteamFDCommon
         }
 
         /// <summary>
-        /// Unpack zip archive
+        /// Unpack fix variant from zip archive
         /// </summary>
         /// <param name="pathToZip">Absolute path to zip file</param>
         /// <param name="unpackTo">Directory to unpack zip to</param>
-        public static async Task UnpackZipAsync(string pathToZip, string unpackTo)
+        /// <param name="variant">Fix variant</param>
+        public static async Task UnpackZipAsync(string pathToZip, string unpackTo, string? variant)
         {
             IProgress<float> progress = Progress;
 
             using (var zip = ZipFile.OpenRead(pathToZip))
             {
-                var count = zip.Entries.Count;
+                var count = variant is null
+                    ? zip.Entries.Count
+                    : zip.Entries.Where(x => x.FullName.StartsWith(variant)).Count();
+
                 var i = 1f;
 
                 await Task.Run(() =>
                 {
                     foreach (var zipEntry in zip.Entries)
                     {
-                        var fullName = Path.Combine(unpackTo, zipEntry.FullName);
+                        if (variant is not null &&
+                        !zipEntry.FullName.StartsWith(variant))
+                        {
+                            continue;
+                        }
+
+                        var fullName = variant is null
+                            ? Path.Combine(unpackTo, zipEntry.FullName)
+                            : Path.Combine(unpackTo, zipEntry.FullName.Replace(variant + "/", string.Empty));
+
+                        var aa = Path.GetFileName(fullName);
 
                         if (Path.GetFileName(fullName).Length == 0)
                         {
@@ -88,7 +102,7 @@ namespace SteamFDCommon
                             zipEntry.ExtractToFile(fullName, true);
                         }
 
-                        progress.Report(i / zip.Entries.Count * 100);
+                        progress.Report(i / count * 100);
 
                         i++;
                     }

--- a/src/Common/FileTools.cs
+++ b/src/Common/FileTools.cs
@@ -59,7 +59,7 @@ namespace SteamFDCommon
         }
 
         /// <summary>
-        /// Unpack fix variant from zip archive
+        /// Unpack fix from zip archive
         /// </summary>
         /// <param name="pathToZip">Absolute path to zip file</param>
         /// <param name="unpackTo">Directory to unpack zip to</param>

--- a/src/Common/FixTools/FixInstaller.cs
+++ b/src/Common/FixTools/FixInstaller.cs
@@ -26,7 +26,7 @@ namespace SteamFDCommon.FixTools
 
             var unpackToPath = fix.InstallFolder is null
                                   ? game.InstallDir
-                                  : Path.Combine(game.InstallDir, fix.InstallFolder, "\\");
+                                  : Path.Combine(game.InstallDir, fix.InstallFolder) + "\\";
 
             if (!File.Exists(zipFullPath))
             {

--- a/src/Common/FixTools/FixInstaller.cs
+++ b/src/Common/FixTools/FixInstaller.cs
@@ -16,7 +16,7 @@ namespace SteamFDCommon.FixTools
         /// </summary>
         /// <param name="game">Game entity</param>
         /// <param name="fix">Fix entity</param>
-        public static async Task<InstalledFixEntity> InstallFix(GameEntity game, FixEntity fix, bool doBackup)
+        public static async Task<InstalledFixEntity> InstallFix(GameEntity game, FixEntity fix, string? variant)
         {
             var zipName = Path.GetFileName(fix.Url);
 
@@ -26,20 +26,20 @@ namespace SteamFDCommon.FixTools
 
             var unpackToPath = fix.InstallFolder is null
                                   ? game.InstallDir
-                                  : Path.Combine(game.InstallDir, fix.InstallFolder);
+                                  : Path.Combine(game.InstallDir, fix.InstallFolder, "\\");
 
             if (!File.Exists(zipFullPath))
             {
                 await FileTools.DownloadFileAsync(new Uri(fix.Url), zipFullPath);
             }
 
-            var filesInArchive = GetListOfFilesInArchive(zipFullPath, fix.InstallFolder, unpackToPath);
+            var filesInArchive = GetListOfFilesInArchive(zipFullPath, fix.InstallFolder, unpackToPath, variant);
 
             var filesToDelete = GetListOfFilesToDelete(game.InstallDir, fix.FilesToDelete);
 
             BackupFiles(filesInArchive.Concat(filesToDelete), game.InstallDir, Path.GetFileNameWithoutExtension(zipName));
 
-            await FileTools.UnpackZipAsync(zipFullPath, unpackToPath);
+            await FileTools.UnpackZipAsync(zipFullPath, unpackToPath, variant);
 
             if (_config.DeleteZipsAfterInstall &&
                 !_config.UseLocalRepo)
@@ -167,7 +167,7 @@ namespace SteamFDCommon.FixTools
         /// <param name="fixInstallFolder">Folder to unpack the ZIP</param>
         /// <param name="unpackToPath">Full path </param>
         /// <returns>List of files and folders (if aren't already exist) in the archive</returns>
-        private static List<string> GetListOfFilesInArchive(string zipPath, string? fixInstallFolder, string unpackToPath)
+        private static List<string> GetListOfFilesInArchive(string zipPath, string? fixInstallFolder, string unpackToPath, string? variant)
         {
             List<string> files = new();
 
@@ -175,9 +175,28 @@ namespace SteamFDCommon.FixTools
             {
                 foreach (ZipArchiveEntry entry in archive.Entries)
                 {
+                    string path = entry.FullName;
+
+                    if (variant is not null)
+                    {
+                        if (entry.FullName.StartsWith(variant+"/"))
+                        {
+                            path = entry.FullName.Replace(variant + "/", string.Empty);
+
+                            if (string.IsNullOrEmpty(path))
+                            {
+                                continue;
+                            }
+                        }
+                        else
+                        {
+                            continue;
+                        }
+                    }
+
                     var fullName = Path.Combine(
                         fixInstallFolder is null ? string.Empty : fixInstallFolder,
-                        entry.FullName)
+                        path)
                         .Replace("/", "\\");
 
                     //if it's a file, add it to the list

--- a/src/Common/Models/MainModel.cs
+++ b/src/Common/Models/MainModel.cs
@@ -161,9 +161,9 @@ namespace SteamFDCommon.Models
         /// <param name="game">Game entity</param>
         /// <param name="fix">Fix to install</param>
         /// <returns>Result message</returns>
-        public async Task<string> InstallFix(GameEntity game, FixEntity fix)
+        public async Task<string> InstallFix(GameEntity game, FixEntity fix, string? variant)
         {
-            var installedFix = await FixInstaller.InstallFix(game, fix, true);
+            var installedFix = await FixInstaller.InstallFix(game, fix, variant);
 
             fix.InstalledFix = installedFix;
 
@@ -185,13 +185,13 @@ namespace SteamFDCommon.Models
         /// <param name="game">Game entity</param>
         /// <param name="fix">Fix to update</param>
         /// <returns>Result message</returns>
-        public async Task<string> UpdateFix(GameEntity game, FixEntity fix)
+        public async Task<string> UpdateFix(GameEntity game, FixEntity fix, string? variant)
         {
             FixUninstaller.UninstallFix(game, fix);
 
             fix.InstalledFix = null;
 
-            var installedFix = await FixInstaller.InstallFix(game, fix, true);
+            var installedFix = await FixInstaller.InstallFix(game, fix, variant);
 
             fix.InstalledFix = installedFix;
 

--- a/src/Common/Providers/GamesProvider.cs
+++ b/src/Common/Providers/GamesProvider.cs
@@ -110,6 +110,11 @@ namespace SteamFDCommon.Providers
 
             if (!string.IsNullOrEmpty(dir) && !string.IsNullOrEmpty(name))
             {
+                if (!dir.EndsWith("\\")) 
+                {
+                    dir += "\\";
+                }
+
                 return new GameEntity(id, name, dir);
             }
 


### PR DESCRIPTION
Fixes variants provide a way to have multiple variants of the same fix and select which one to install.

It will be the most useful for (ultra)widescreen fixes that are distributed as a modified exes. Each fix will have multiple variants for different resolutions and the user will be able to select the one he needs from a combo box.

![image](https://github.com/fgsfds/Steam-Superheater/assets/4870330/ecd7695e-18ec-4750-8828-871838fcbbbd)

Each variant is located in a subfolder inside a zip archive

![image](https://github.com/fgsfds/Steam-Superheater/assets/4870330/6e2195fe-4dcd-48ac-87bf-981c40e7238e)

and in fixes.xml it's represented by a list of strings with the same names as subfolders

```
<FixEntity>
        <Guid>d207c355-0d68-43fd-a1ee-16a931421145</Guid>
        <Url>https://github.com/fgsfds/SteamFD-Fixes-Repo/raw/master/fixes/desperados_resolutions.zip</Url>
        <Description />
        <Variants>
          <string>1920x1080</string>
          <string>2560x1080</string>
        </Variants>
        <Dependencies />
        <Name>Resolution Fix</Name>
        <Version>1</Version>
</FixEntity>
```