### PR TITLE
Feature: MD5 check for downloaded files

### DIFF
--- a/src/Avalonia/Superheater.Avalonia.Core/UserControls/EditorFields.axaml
+++ b/src/Avalonia/Superheater.Avalonia.Core/UserControls/EditorFields.axaml
@@ -2,7 +2,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="600"
              x:Class="Superheater.Avalonia.Core.UserControls.EditorFields">
     <Grid>
         <Grid.RowDefinitions>
@@ -105,10 +105,17 @@
                  IsReadOnly="{Binding !IsEditingAvailable}"
                  Margin="0,3"/>
 
-        <!--Run after install-->
+        <!--Tags-->
         <TextBox Text="{Binding SelectedFixTags, Mode=TwoWay}"
                  Watermark="Tags"
                  Grid.Row="9"
+                 IsReadOnly="{Binding !IsEditingAvailable}"
+                 Margin="0,3"/>
+
+        <!--MD5-->
+        <TextBox Text="{Binding SelectedFixMD5, Mode=TwoWay}"
+                 Watermark="MD5"
+                 Grid.Row="10"
                  IsReadOnly="{Binding !IsEditingAvailable}"
                  Margin="0,3"/>
 

--- a/src/Avalonia/Superheater.Avalonia.Core/UserControls/PopupMessage.axaml
+++ b/src/Avalonia/Superheater.Avalonia.Core/UserControls/PopupMessage.axaml
@@ -52,7 +52,7 @@
             <Grid ColumnDefinitions="*,*"
                   Grid.Row="2"
                   Grid.ColumnSpan="2"
-                  IsVisible="{Binding IsOkCancel}">
+                  IsVisible="{Binding IsYesNo}">
 
                 <Button Grid.Column="0"
                         HorizontalAlignment="Center"
@@ -65,7 +65,7 @@
                         Command="{Binding OkCommand}"
                         Background="{DynamicResource SystemAccentColor}"
                         IsEnabled="True">
-                    OK
+                    Yes
                 </Button>
 
                 <Button Grid.Column="1"
@@ -77,7 +77,7 @@
                         Width="150"
                         Height="50"
                         Command="{Binding CancelCommand}">
-                    Cancel
+                    No
                 </Button>
 
             </Grid>
@@ -97,7 +97,7 @@
                         Width="150"
                         Height="50"
                         Background="{DynamicResource SystemAccentColor}"
-                        Command="{Binding CancelCommand}">
+                        Command="{Binding OkCommand}">
                     OK
                 </Button>
 

--- a/src/Avalonia/Superheater.Avalonia.Core/ViewModels/AboutViewModel.cs
+++ b/src/Avalonia/Superheater.Avalonia.Core/ViewModels/AboutViewModel.cs
@@ -22,7 +22,7 @@ namespace Superheater.Avalonia.Core.ViewModels
 
         #region Binding Properties
 
-        public Version CurrentVersion => CommonProperties.CurrentVersion;
+        public static Version CurrentVersion => CommonProperties.CurrentVersion;
 
 
         public string AboutTabHeader { get; private set; }

--- a/src/Avalonia/Superheater.Avalonia.Core/ViewModels/EditorViewModel.cs
+++ b/src/Avalonia/Superheater.Avalonia.Core/ViewModels/EditorViewModel.cs
@@ -10,6 +10,7 @@ using CommunityToolkit.Mvvm.Input;
 using Superheater.Avalonia.Core.Helpers;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Security.Cryptography;
 
 namespace Superheater.Avalonia.Core.ViewModels
 {
@@ -107,6 +108,24 @@ namespace Superheater.Avalonia.Core.ViewModels
                 else
                 {
                     SelectedFix.Url = value;
+                }
+            }
+        }
+
+        public string SelectedFixMD5
+        {
+            get => SelectedFix?.MD5 ?? string.Empty;
+            set
+            {
+                if (SelectedFix is null) throw new NullReferenceException(nameof(SelectedFix));
+
+                if (string.IsNullOrWhiteSpace(value))
+                {
+                    SelectedFix.MD5 = null;
+                }
+                else
+                {
+                    SelectedFix.MD5 = value;
                 }
             }
         }

--- a/src/Avalonia/Superheater.Avalonia.Core/ViewModels/EditorViewModel.cs
+++ b/src/Avalonia/Superheater.Avalonia.Core/ViewModels/EditorViewModel.cs
@@ -192,6 +192,7 @@ namespace Superheater.Avalonia.Core.ViewModels
         [NotifyPropertyChangedFor(nameof(IsLinuxChecked))]
         [NotifyPropertyChangedFor(nameof(SelectedFixUrl))]
         [NotifyPropertyChangedFor(nameof(SelectedFixTags))]
+        [NotifyPropertyChangedFor(nameof(SelectedFixMD5))]
         [NotifyCanExecuteChangedFor(nameof(RemoveFixCommand))]
         [NotifyCanExecuteChangedFor(nameof(MoveFixDownCommand))]
         [NotifyCanExecuteChangedFor(nameof(MoveFixUpCommand))]
@@ -283,9 +284,9 @@ namespace Superheater.Avalonia.Core.ViewModels
         /// Save fixes.xml
         /// </summary>
         [RelayCommand]
-        private void SaveChanges()
+        private async Task SaveChangesAsync()
         {
-            var result = _editorModel.SaveFixesListAsync();
+            var result = await _editorModel.SaveFixesListAsync();
 
             new PopupMessageViewModel(
                 result.Item1 ? "Success" : "Error",

--- a/src/Avalonia/Superheater.Avalonia.Core/ViewModels/EditorViewModel.cs
+++ b/src/Avalonia/Superheater.Avalonia.Core/ViewModels/EditorViewModel.cs
@@ -247,7 +247,7 @@ namespace Superheater.Avalonia.Core.ViewModels
         {
             if (SelectedGame is null) throw new NullReferenceException(nameof(SelectedGame));
 
-            var newFix = _editorModel.AddNewFix(SelectedGame);
+            var newFix = EditorModel.AddNewFix(SelectedGame);
 
             OnPropertyChanged(nameof(SelectedGameFixesList));
 
@@ -265,7 +265,7 @@ namespace Superheater.Avalonia.Core.ViewModels
             if (SelectedGame is null) throw new NullReferenceException(nameof(SelectedGame));
             if (SelectedFix is null) throw new NullReferenceException(nameof(SelectedFix));
 
-            _editorModel.RemoveFix(SelectedGame, SelectedFix);
+            EditorModel.RemoveFix(SelectedGame, SelectedFix);
 
             OnPropertyChanged(nameof(SelectedGameFixesList));
         }
@@ -289,8 +289,8 @@ namespace Superheater.Avalonia.Core.ViewModels
             var result = await _editorModel.SaveFixesListAsync();
 
             new PopupMessageViewModel(
-                result.Item1 ? "Success" : "Error",
-                result.Item2,
+                result.IsSuccess ? "Success" : "Error",
+                result.Message,
                 PopupMessageType.OkOnly)
                 .Show();
         }
@@ -316,7 +316,7 @@ namespace Superheater.Avalonia.Core.ViewModels
         {
             if (SelectedFix is null) throw new NullReferenceException(nameof(SelectedFix));
 
-            _editorModel.AddDependencyForFix(SelectedFix, AvailableDependenciesList.ElementAt(SelectedAvailableDependencyIndex));
+            EditorModel.AddDependencyForFix(SelectedFix, AvailableDependenciesList.ElementAt(SelectedAvailableDependencyIndex));
 
             OnPropertyChanged(nameof(AvailableDependenciesList));
             OnPropertyChanged(nameof(SelectedFixDependenciesList));
@@ -332,7 +332,7 @@ namespace Superheater.Avalonia.Core.ViewModels
         {
             if (SelectedFix is null) throw new NullReferenceException(nameof(SelectedFix));
 
-            _editorModel.RemoveDependencyForFix(SelectedFix, SelectedFixDependenciesList.ElementAt(SelectedDependencyIndex));
+            EditorModel.RemoveDependencyForFix(SelectedFix, SelectedFixDependenciesList.ElementAt(SelectedDependencyIndex));
 
             OnPropertyChanged(nameof(AvailableDependenciesList));
             OnPropertyChanged(nameof(SelectedFixDependenciesList));
@@ -366,7 +366,7 @@ namespace Superheater.Avalonia.Core.ViewModels
         {
             if (SelectedGame is null) throw new NullReferenceException(nameof(SelectedGame));
 
-            _editorModel.MoveFixUp(SelectedGame.Fixes, SelectedFixIndex);
+            EditorModel.MoveFixUp(SelectedGame.Fixes, SelectedFixIndex);
 
             OnPropertyChanged(nameof(SelectedGameFixesList));
             MoveFixDownCommand.NotifyCanExecuteChanged();
@@ -383,7 +383,7 @@ namespace Superheater.Avalonia.Core.ViewModels
         {
             if (SelectedGame is null) throw new NullReferenceException(nameof(SelectedGame));
 
-            _editorModel.MoveFixDown(SelectedGame.Fixes, SelectedFixIndex);
+            EditorModel.MoveFixDown(SelectedGame.Fixes, SelectedFixIndex);
 
             OnPropertyChanged(nameof(SelectedGameFixesList));
             MoveFixDownCommand.NotifyCanExecuteChanged();
@@ -402,11 +402,11 @@ namespace Superheater.Avalonia.Core.ViewModels
 
             var canUpload = await _editorModel.CheckFixBeforeUploadAsync(SelectedFix);
 
-            if (!canUpload.Item1)
+            if (!canUpload.IsSuccess)
             {
                 new PopupMessageViewModel(
                     "Error",
-                    canUpload.Item2,
+                    canUpload.Message,
                     PopupMessageType.OkOnly)
                     .Show();
 
@@ -416,11 +416,11 @@ namespace Superheater.Avalonia.Core.ViewModels
             var fixesList = SelectedGame ?? throw new NullReferenceException(nameof(SelectedFix));
             var fix = SelectedFix ?? throw new NullReferenceException(nameof(SelectedFix));
 
-            var result = _editorModel.UploadFix(fixesList, fix);
+            var result = EditorModel.UploadFix(fixesList, fix);
 
             new PopupMessageViewModel(
-                    result.Item1 ? "Success" : "Error",
-                    result.Item2,
+                    result.IsSuccess ? "Success" : "Error",
+                    result.Message,
                     PopupMessageType.OkOnly)
                 .Show();
         }
@@ -475,11 +475,11 @@ namespace Superheater.Avalonia.Core.ViewModels
 
             FillGamesList();
 
-            if (!result.Item1)
+            if (!result.IsSuccess)
             {
                 new PopupMessageViewModel(
                     "Error",
-                    result.Item2,
+                    result.Message,
                     PopupMessageType.OkOnly
                     ).Show();
             }

--- a/src/Avalonia/Superheater.Avalonia.Core/ViewModels/EditorViewModel.cs
+++ b/src/Avalonia/Superheater.Avalonia.Core/ViewModels/EditorViewModel.cs
@@ -131,7 +131,7 @@ namespace Superheater.Avalonia.Core.ViewModels
         }
 
 
-        public bool IsDeveloperMode => Properties.IsDeveloperMode;
+        public static bool IsDeveloperMode => Properties.IsDeveloperMode;
 
         public bool IsEditingAvailable => SelectedFix is not null;
 

--- a/src/Avalonia/Superheater.Avalonia.Core/ViewModels/NewsViewModel.cs
+++ b/src/Avalonia/Superheater.Avalonia.Core/ViewModels/NewsViewModel.cs
@@ -52,11 +52,11 @@ namespace Superheater.Avalonia.Core.ViewModels
         {
             var result = await _newsModel.MarkAllAsReadAsync();
 
-            if (!result.Item1)
+            if (!result.IsSuccess)
             {
                 new PopupMessageViewModel(
                     "Error",
-                    result.Item2,
+                    result.Message,
                     PopupMessageType.OkOnly
                     ).Show();
 
@@ -80,11 +80,11 @@ namespace Superheater.Avalonia.Core.ViewModels
             await _locker.WaitAsync();
             var result = await _newsModel.UpdateNewsListAsync();
 
-            if (!result.Item1)
+            if (!result.IsSuccess)
             {
                 new PopupMessageViewModel(
                     "Error",
-                    result.Item2,
+                    result.Message,
                     PopupMessageType.OkOnly
                     ).Show();
 

--- a/src/Common/DI/CommonBindings.cs
+++ b/src/Common/DI/CommonBindings.cs
@@ -9,7 +9,7 @@ namespace Common.DI
         {
             container.Register<UpdateInstaller>(Lifestyle.Singleton);
             container.Register<FixInstaller>(Lifestyle.Singleton);
-            container.Register<FixUninstaller>(Lifestyle.Singleton);
+            //container.Register<FixUninstaller>(Lifestyle.Singleton);
         }
     }
 }

--- a/src/Common/DI/ProvidersBindings.cs
+++ b/src/Common/DI/ProvidersBindings.cs
@@ -13,7 +13,6 @@ namespace Common.DI
             container.Register<GamesProvider>(Lifestyle.Singleton);
             container.Register<NewsProvider>(Lifestyle.Singleton);
             container.Register<FixesProvider>(Lifestyle.Singleton);
-            container.Register<InstalledFixesProvider>(Lifestyle.Singleton);
         }
     }
 }

--- a/src/Common/Entities/FixEntity.cs
+++ b/src/Common/Entities/FixEntity.cs
@@ -1,5 +1,6 @@
 ﻿using Common.Enums;
 using CommunityToolkit.Mvvm.ComponentModel;
+using System.Security.Cryptography;
 using System.Xml.Serialization;
 
 namespace Common.Entities
@@ -63,6 +64,7 @@ namespace Common.Entities
             RunAfterInstall = null;
             Dependencies = null;
             Tags = null;
+            MD5 = null;
         }
 
         /// <summary>
@@ -152,6 +154,11 @@ namespace Common.Entities
         /// Supported OSes
         /// </summary>
         public OSEnum SupportedOSes { get; set; }
+
+        /// <summary>
+        /// Zip archive MD5
+        /// </summary>
+        public string? MD5 { get; set; }
 
         /// <summary>
         /// Is fix installed

--- a/src/Common/Entities/InstalledFixEntity.cs
+++ b/src/Common/Entities/InstalledFixEntity.cs
@@ -2,7 +2,7 @@
 {
     public sealed class InstalledFixEntity
     {
-        public InstalledFixEntity(int id, Guid guid, int version, string backupFolder, List<string> list)
+        public InstalledFixEntity(int id, Guid guid, int version, string backupFolder, List<string>? list)
         {
             GameId = id;
             Guid = guid;
@@ -34,7 +34,7 @@
         /// <summary>
         /// Paths to files relative to the game folder
         /// </summary>
-        public List<string> FilesList { get; init; }
+        public List<string>? FilesList { get; init; }
 
         /// <summary>
         /// Serializer constructor

--- a/src/Common/FileTools.cs
+++ b/src/Common/FileTools.cs
@@ -17,7 +17,7 @@ namespace Common
         /// <param name="url">Link to file download</param>
         /// <param name="filePath">Absolute path to destination file</param>
         /// <param name="hash">MD5 to check file against</param>
-        /// <exception cref="Exception"></exception>
+        /// <exception cref="Exception">Error while downloading file</exception>
         /// <exception cref="HashCheckFailedException">MD5 of the downloaded file doesn't match provided MD5</exception>
         public static async Task CheckAndDownloadFileAsync(Uri url, string filePath, string? hash = null)
         {

--- a/src/Common/FixTools/FIxUninstaller.cs
+++ b/src/Common/FixTools/FIxUninstaller.cs
@@ -3,14 +3,14 @@ using Common.Helpers;
 
 namespace Common.FixTools
 {
-    public sealed class FixUninstaller
+    public static class FixUninstaller
     {
         /// <summary>
         /// Uninstall fix: delete files, restore backup
         /// </summary>
         /// <param name="game">Game entity</param>
         /// <param name="fix">Fix entity</param>
-        public void UninstallFix(GameEntity game, InstalledFixEntity fix)
+        public static void UninstallFix(GameEntity game, InstalledFixEntity fix)
         {
             if (fix is null) throw new NullReferenceException(nameof(fix));
 
@@ -26,8 +26,10 @@ namespace Common.FixTools
         /// </summary>
         /// <param name="gameInstallDir">Game install folder</param>
         /// <param name="fixFiles">Files to delete</param>
-        private void DeleteFiles(string gameInstallDir, List<string> fixFiles)
+        private static void DeleteFiles(string gameInstallDir, List<string>? fixFiles)
         {
+            if (fixFiles is null) return;
+
             foreach (var file in fixFiles)
             {
                 var fullPath = Path.Combine(gameInstallDir, file);

--- a/src/Common/FixTools/FixInstaller.cs
+++ b/src/Common/FixTools/FixInstaller.cs
@@ -24,7 +24,7 @@ namespace Common.FixTools
         /// <param name="skipMD5Check">Don't check file against fix's MD5 hash</param>
         /// <exception cref="Exception">Error while downloading file</exception>
         /// <exception cref="HashCheckFailedException">MD5 of the downloaded file doesn't match provided MD5</exception>
-        public async Task<InstalledFixEntity> InstallFix(GameEntity game, FixEntity fix, string? variant, bool skipMD5Check = false)
+        public async Task<InstalledFixEntity> InstallFix(GameEntity game, FixEntity fix, string? variant, bool skipMD5Check)
         {
             await CheckAndDownloadFileAsync(fix.Url, skipMD5Check ? null : fix.MD5);
 

--- a/src/Common/Helpers/Exceptions.cs
+++ b/src/Common/Helpers/Exceptions.cs
@@ -1,0 +1,8 @@
+﻿namespace Common.Helpers
+{
+    public class HashCheckFailedException : Exception
+    {
+        public HashCheckFailedException(string message)
+            : base(message) { }
+    }
+}

--- a/src/Common/Helpers/Extensions.cs
+++ b/src/Common/Helpers/Extensions.cs
@@ -28,8 +28,8 @@ namespace Common.Helpers
         public static void Move<T>(this List<T> list, int oldIndex, int newIndex)
         {
             var element = list[oldIndex];
-            list.RemoveAt(oldIndex);
 
+            list.RemoveAt(oldIndex);
             list.Insert(newIndex, element);
         }
 
@@ -37,10 +37,10 @@ namespace Common.Helpers
         {
             var element = list[oldIndex];
 
-            var newList = list.RemoveAt(oldIndex);
-            newList = list.Insert(newIndex, element);
+            list = list.RemoveAt(oldIndex);
+            list = list.Insert(newIndex, element);
 
-            return newList;
+            return list;
         }
     }
 }

--- a/src/Common/Helpers/GameEntityHelper.cs
+++ b/src/Common/Helpers/GameEntityHelper.cs
@@ -59,6 +59,6 @@ namespace Common.Helpers
         /// Game executable
         /// Only defined if the game requires admin rights, otherwise is null
         /// </summary>
-        private static string? GetGameExecutable(int id) => _gamesThatRequireAdmin.ContainsKey(id) ? _gamesThatRequireAdmin[key: id] : null;
+        private static string? GetGameExecutable(int id) => _gamesThatRequireAdmin.TryGetValue(id, out string? value) ? value : null;
     }
 }

--- a/src/Common/Helpers/Result.cs
+++ b/src/Common/Helpers/Result.cs
@@ -1,0 +1,56 @@
+﻿namespace Common.Helpers
+{
+    /// <summary>
+    /// Operation result
+    /// </summary>
+    public readonly struct Result
+    {
+        public Result(
+            ResultEnum resultEnum,
+            string message
+            )
+        {
+            ResultEnum = resultEnum;
+            Message = message;
+        }
+
+        /// <summary>
+        /// Operation result enum
+        /// </summary>
+        public ResultEnum ResultEnum { get; init; }
+
+        /// <summary>
+        /// Operation result message
+        /// </summary>
+        public string Message { get; init; }
+
+        /// <summary>
+        /// Is operation successful
+        /// </summary>
+        public bool IsSuccess => ResultEnum is ResultEnum.Ok;
+    }
+
+    public enum ResultEnum
+    {
+        /// <summary>
+        /// Successful operation
+        /// </summary>
+        Ok,
+        /// <summary>
+        /// Error while validating MD5
+        /// </summary>
+        MD5Error,
+        /// <summary>
+        /// File not found
+        /// </summary>
+        FileNotFound,
+        /// <summary>
+        /// Connection to online resource failed
+        /// </summary>
+        ConnectionError,
+        /// <summary>
+        /// General error
+        /// </summary>
+        Error
+    }
+}

--- a/src/Common/Helpers/Result.cs
+++ b/src/Common/Helpers/Result.cs
@@ -41,9 +41,9 @@
         /// </summary>
         MD5Error,
         /// <summary>
-        /// File not found
+        /// File or directory not found
         /// </summary>
-        FileNotFound,
+        NotFound,
         /// <summary>
         /// Connection to online resource failed
         /// </summary>

--- a/src/Common/Models/EditorModel.cs
+++ b/src/Common/Models/EditorModel.cs
@@ -44,11 +44,10 @@ namespace Common.Models
             }
             catch (Exception ex) when (ex is FileNotFoundException || ex is DirectoryNotFoundException)
             {
-                return new(ResultEnum.FileNotFound, $"File not found: {ex.Message}");
+                return new(ResultEnum.NotFound, $"File not found: {ex.Message}");
             }
             catch (Exception ex) when (ex is HttpRequestException || ex is TaskCanceledException)
             {
-
                 return new(ResultEnum.ConnectionError, "Can't connect to GitHub repository");
             }
         }

--- a/src/Common/Models/EditorModel.cs
+++ b/src/Common/Models/EditorModel.cs
@@ -127,9 +127,9 @@ namespace Common.Models
         /// Save current fixes list to XML
         /// </summary>
         /// <returns>Result message</returns>
-        public Tuple<bool, string> SaveFixesListAsync()
+        public async Task<Tuple<bool, string>> SaveFixesListAsync()
         {
-            var result = _fixesProvider.SaveFixes(_fixesList);
+            var result = await _fixesProvider.SaveFixesAsync(_fixesList);
 
             CreateReadme();
 

--- a/src/Common/Models/EditorModel.cs
+++ b/src/Common/Models/EditorModel.cs
@@ -33,23 +33,23 @@ namespace Common.Models
         /// Update list of fixes either from cache or by downloading fixes.xml from repo
         /// </summary>
         /// <param name="useCache">Is cache used</param>
-        public async Task<Tuple<bool, string>> UpdateListsAsync(bool useCache)
+        public async Task<Result> UpdateListsAsync(bool useCache)
         {
             try
             {
                 await GetListOfFixesAsync(useCache);
                 await GetListOfAvailableGamesAsync(useCache);
 
-                return new(true, string.Empty);
+                return new(ResultEnum.Ok, string.Empty);
             }
             catch (Exception ex) when (ex is FileNotFoundException || ex is DirectoryNotFoundException)
             {
-                return new(false, $"File not found: {ex.Message}");
+                return new(ResultEnum.FileNotFound, $"File not found: {ex.Message}");
             }
             catch (Exception ex) when (ex is HttpRequestException || ex is TaskCanceledException)
             {
 
-                return new(false, "Can't connect to GitHub repository");
+                return new(ResultEnum.ConnectionError, "Can't connect to GitHub repository");
             }
         }
 
@@ -99,7 +99,7 @@ namespace Common.Models
         /// </summary>
         /// <param name="game">Game entity</param>
         /// <returns>New fix entity</returns>
-        public FixEntity AddNewFix(FixesList game)
+        public static FixEntity AddNewFix(FixesList game)
         {
             FixEntity newFix = new();
 
@@ -113,7 +113,7 @@ namespace Common.Models
         /// </summary>
         /// <param name="game">Game entity</param>
         /// <param name="fix">Fix entity</param>
-        public void RemoveFix(FixesList game, FixEntity fix)
+        public static void RemoveFix(FixesList game, FixEntity fix)
         {
             game.Fixes.Remove(fix);
 
@@ -127,9 +127,9 @@ namespace Common.Models
         /// Save current fixes list to XML
         /// </summary>
         /// <returns>Result message</returns>
-        public async Task<Tuple<bool, string>> SaveFixesListAsync()
+        public async Task<Result> SaveFixesListAsync()
         {
-            var result = await _fixesProvider.SaveFixesAsync(_fixesList);
+            var result = await FixesProvider.SaveFixesAsync(_fixesList);
 
             CreateReadme();
 
@@ -206,7 +206,7 @@ namespace Common.Models
         /// <param name="fixesList">Fixes list entity</param>
         /// <param name="fix">New fix</param>
         /// <returns>true if uploaded successfully</returns>
-        public Tuple<bool, string> UploadFix(FixesList fixesList, FixEntity fix)
+        public static Result UploadFix(FixesList fixesList, FixEntity fix)
         {
             var newFix = new FixesList(
                 fixesList.GameId,
@@ -247,14 +247,14 @@ namespace Common.Models
 
                 if (result)
                 {
-                    return new(true, @$"Fix successfully uploaded.
+                    return new(ResultEnum.Ok, @$"Fix successfully uploaded.
 It will be added to the database after developer's review.
 
 Thank you.");
                 }
                 else
                 {
-                    return new(false, "Can't upload fix.");
+                    return new(ResultEnum.Error, "Can't upload fix.");
                 }
             }
         }
@@ -262,12 +262,12 @@ Thank you.");
         /// <summary>
         /// Check if the file can be uploaded
         /// </summary>
-        public async Task<Tuple<bool, string>> CheckFixBeforeUploadAsync(FixEntity fix)
+        public async Task<Result> CheckFixBeforeUploadAsync(FixEntity fix)
         {
             if (string.IsNullOrEmpty(fix?.Name) ||
                 fix.Version < 1)
             {
-                return new(false, "Name and Version are required to upload a fix.");
+                return new(ResultEnum.Error, "Name and Version are required to upload a fix.");
             }
 
             if (!string.IsNullOrEmpty(fix.Url) &&
@@ -275,12 +275,12 @@ Thank you.");
             {
                 if (!File.Exists(fix.Url))
                 {
-                    return new(false, $"{fix.Url} doesn't exist.");
+                    return new(ResultEnum.Error, $"{fix.Url} doesn't exist.");
                 }
 
                 else if (new FileInfo(fix.Url).Length > 1e+8)
                 {
-                    return new(false, $"Can't upload file larger than 100Mb.{Environment.NewLine}{Environment.NewLine}Please, upload it to file hosting.");
+                    return new(ResultEnum.Error, $"Can't upload file larger than 100Mb.{Environment.NewLine}{Environment.NewLine}Please, upload it to file hosting.");
                 }
             }
 
@@ -291,28 +291,28 @@ Thank you.");
                 //if fix already exists in the repo, don't upload it
                 if (onlineFix.Fixes.Any(x => x.Guid == fix.Guid))
                 {
-                    return new(false, $"Can't upload fix.{Environment.NewLine}{Environment.NewLine}This fix already exists in the database.");
+                    return new(ResultEnum.Error, $"Can't upload fix.{Environment.NewLine}{Environment.NewLine}This fix already exists in the database.");
                 }
             }
 
-            return new(true, string.Empty);
+            return new(ResultEnum.Ok, string.Empty);
         }
 
-        public void AddDependencyForFix(FixEntity addTo, FixEntity dependency)
+        public static void AddDependencyForFix(FixEntity addTo, FixEntity dependency)
         {
             addTo.Dependencies ??= new();
             addTo.Dependencies.Add(dependency.Guid);
         }
 
-        public void RemoveDependencyForFix(FixEntity addTo, FixEntity dependency)
+        public static void RemoveDependencyForFix(FixEntity addTo, FixEntity dependency)
         {
             addTo.Dependencies ??= new();
             addTo.Dependencies.Remove(dependency.Guid);
         }
 
-        public void MoveFixUp(List<FixEntity> fixesList, int index) => fixesList.Move(index, index - 1);
+        public static void MoveFixUp(List<FixEntity> fixesList, int index) => fixesList.Move(index, index - 1);
 
-        public void MoveFixDown(List<FixEntity> fixesList, int index) => fixesList.Move(index, index + 1);
+        public static void MoveFixDown(List<FixEntity> fixesList, int index) => fixesList.Move(index, index + 1);
 
         /// <summary>
         /// Get sorted list of fixes

--- a/src/Common/Models/MainModel.cs
+++ b/src/Common/Models/MainModel.cs
@@ -314,7 +314,7 @@ namespace Common.Models
             }
             catch (Exception ex)
             {
-                return new(false, "Error while downloading fix: " + Environment.NewLine + Environment.NewLine + ex.Message);
+                return new(false, "Error while installing fix: " + Environment.NewLine + Environment.NewLine + ex.Message);
             }
 
             fix.InstalledFix = installedFix;

--- a/src/Common/Models/MainModel.cs
+++ b/src/Common/Models/MainModel.cs
@@ -312,6 +312,10 @@ namespace Common.Models
             {
                 installedFix = await _fixInstaller.InstallFix(game, fix, variant);
             }
+            //catch (HashCheckFailedException ex)
+            //{
+
+            //}
             catch (Exception ex)
             {
                 return new(false, "Error while installing fix: " + Environment.NewLine + Environment.NewLine + ex.Message);
@@ -353,7 +357,7 @@ namespace Common.Models
             }
             catch (Exception ex)
             {
-                return new(false, "Error while downloading fix: " + Environment.NewLine + Environment.NewLine + ex.Message);
+                return new(false, "Error while installing fix: " + Environment.NewLine + Environment.NewLine + ex.Message);
             }
 
             fix.InstalledFix = installedFix;

--- a/src/Common/Models/MainModel.cs
+++ b/src/Common/Models/MainModel.cs
@@ -3,6 +3,7 @@ using Common.Config;
 using Common.Entities;
 using Common.Enums;
 using Common.FixTools;
+using Common.Helpers;
 using Common.Providers;
 using System.Collections.Immutable;
 
@@ -12,25 +13,19 @@ namespace Common.Models
     {
         public MainModel(
             ConfigProvider configProvider,
-            InstalledFixesProvider installedFixesProvider,
             CombinedEntitiesProvider combinedEntitiesProvider,
-            FixInstaller fixInstaller,
-            FixUninstaller fixUninstaller
+            FixInstaller fixInstaller
             )
         {
             _combinedEntitiesList = new();
             _config = configProvider?.Config ?? throw new NullReferenceException(nameof(configProvider));
-            _installedFixesProvider = installedFixesProvider ?? throw new NullReferenceException(nameof(installedFixesProvider));
             _combinedEntitiesProvider = combinedEntitiesProvider ?? throw new NullReferenceException(nameof(combinedEntitiesProvider));
             _fixInstaller = fixInstaller ?? throw new NullReferenceException(nameof(fixInstaller));
-            _fixUninstaller = fixUninstaller ?? throw new NullReferenceException(nameof(fixUninstaller));
         }
 
         private readonly ConfigEntity _config;
-        private readonly InstalledFixesProvider _installedFixesProvider;
         private readonly CombinedEntitiesProvider _combinedEntitiesProvider;
         private readonly FixInstaller _fixInstaller;
-        private readonly FixUninstaller _fixUninstaller;
 
         private readonly List<FixFirstCombinedEntity> _combinedEntitiesList;
 
@@ -42,7 +37,7 @@ namespace Common.Models
         /// Update list of games either from cache or by downloading fixes.xml from repo
         /// </summary>
         /// <param name="useCache">Is cache used</param>
-        public async Task<Tuple<bool, string>> UpdateGamesListAsync(bool useCache)
+        public async Task<Result> UpdateGamesListAsync(bool useCache)
         {
             _combinedEntitiesList.Clear();
 
@@ -87,15 +82,15 @@ namespace Common.Models
 
                 _combinedEntitiesList.AddRange(games);
 
-                return new(true, string.Empty);
+                return new(ResultEnum.Ok, "Games list updated successfully");
             }
             catch (Exception ex) when (ex is FileNotFoundException || ex is DirectoryNotFoundException)
             {
-                return new(false, "File not found: " + ex.Message);
+                return new(ResultEnum.FileNotFound, "File not found: " + ex.Message);
             }
             catch (Exception ex) when (ex is HttpRequestException || ex is TaskCanceledException)
             {
-                return new(false, "Can't connect to GitHub repository");
+                return new(ResultEnum.ConnectionError, "Can't connect to GitHub repository");
             }
         }
 
@@ -250,7 +245,7 @@ namespace Common.Models
         /// <param name="fixes">List of fix entities</param>
         /// <param name="guid">Guid of a fix</param>
         /// <returns>List of dependent fixes</returns>
-        public List<FixEntity> GetDependentFixes(IEnumerable<FixEntity> fixes, Guid guid)
+        public static List<FixEntity> GetDependentFixes(IEnumerable<FixEntity> fixes, Guid guid)
             => fixes.Where(x => x.Dependencies is not null && x.Dependencies.Contains(guid)).ToList();
 
         /// <summary>
@@ -259,7 +254,7 @@ namespace Common.Models
         /// <param name="fixes">List of fix entities</param>
         /// <param name="guid">Guid of a fix</param>
         /// <returns>true if there are installed dependent fixes</returns>
-        public bool DoesFixHaveInstalledDependentFixes(IEnumerable<FixEntity> fixes, Guid guid)
+        public static bool DoesFixHaveInstalledDependentFixes(IEnumerable<FixEntity> fixes, Guid guid)
         {
             var deps = GetDependentFixes(fixes, guid);
 
@@ -278,23 +273,23 @@ namespace Common.Models
         /// <param name="game">Game entity</param>
         /// <param name="fix">Fix to delete</param>
         /// <returns>Result message</returns>
-        public Tuple<bool, string> UninstallFix(GameEntity game, FixEntity fix)
+        public Result UninstallFix(GameEntity game, FixEntity fix)
         {
             if (fix.InstalledFix is null) throw new NullReferenceException(nameof(fix.InstalledFix));
 
-            _fixUninstaller.UninstallFix(game, fix.InstalledFix);
+            FixUninstaller.UninstallFix(game, fix.InstalledFix);
 
             fix.InstalledFix = null;
 
-            var result = _installedFixesProvider.SaveInstalledFixes(_combinedEntitiesList);
+            var result = InstalledFixesProvider.SaveInstalledFixes(_combinedEntitiesList);
 
-            if (result.Item1)
+            if (result.IsSuccess)
             {
-                return new(true, "Fix uninstalled successfully!");
+                return new(ResultEnum.Ok, "Fix uninstalled successfully!");
             }
             else
             {
-                return new(false, result.Item2);
+                return new(ResultEnum.Error, result.Message);
             }
         }
 
@@ -304,34 +299,34 @@ namespace Common.Models
         /// <param name="game">Game entity</param>
         /// <param name="fix">Fix to install</param>
         /// <returns>Result message</returns>
-        public async Task<Tuple<bool, string>> InstallFix(GameEntity game, FixEntity fix, string? variant)
+        public async Task<Result> InstallFix(GameEntity game, FixEntity fix, string? variant, bool skipMD5Check = false)
         {
             InstalledFixEntity? installedFix;
 
             try
             {
-                installedFix = await _fixInstaller.InstallFix(game, fix, variant);
+                installedFix = await _fixInstaller.InstallFix(game, fix, variant, skipMD5Check);
             }
-            //catch (HashCheckFailedException ex)
-            //{
-
-            //}
+            catch (HashCheckFailedException)
+            {
+                return new(ResultEnum.MD5Error, "MD5 of the file doesn't match the database");
+            }
             catch (Exception ex)
             {
-                return new(false, "Error while installing fix: " + Environment.NewLine + Environment.NewLine + ex.Message);
+                return new(ResultEnum.Error, "Error while installing fix: " + Environment.NewLine + Environment.NewLine + ex.Message);
             }
 
             fix.InstalledFix = installedFix;
 
-            var result = _installedFixesProvider.SaveInstalledFixes(_combinedEntitiesList);
+            var result = InstalledFixesProvider.SaveInstalledFixes(_combinedEntitiesList);
 
-            if (result.Item1)
+            if (result.IsSuccess)
             {
-                return new(true, "Fix installed successfully!");
+                return new(ResultEnum.Ok, "Fix installed successfully!");
             }
             else
             {
-                return new(false, result.Item2);
+                return new(ResultEnum.Error, result.Message);
             }
         }
 
@@ -341,11 +336,11 @@ namespace Common.Models
         /// <param name="game">Game entity</param>
         /// <param name="fix">Fix to update</param>
         /// <returns>Result message</returns>
-        public async Task<Tuple<bool, string>> UpdateFix(GameEntity game, FixEntity fix, string? variant)
+        public async Task<Result> UpdateFix(GameEntity game, FixEntity fix, string? variant)
         {
             if (fix.InstalledFix is null) throw new NullReferenceException(nameof(fix.InstalledFix));
 
-            _fixUninstaller.UninstallFix(game, fix.InstalledFix);
+            FixUninstaller.UninstallFix(game, fix.InstalledFix);
 
             fix.InstalledFix = null;
 
@@ -355,22 +350,26 @@ namespace Common.Models
             {
                 installedFix = await _fixInstaller.InstallFix(game, fix, variant);
             }
+            catch (HashCheckFailedException)
+            {
+                return new(ResultEnum.MD5Error, "MD5 of the file doesn't match the database");
+            }
             catch (Exception ex)
             {
-                return new(false, "Error while installing fix: " + Environment.NewLine + Environment.NewLine + ex.Message);
+                return new(ResultEnum.Error, "Error while installing fix: " + Environment.NewLine + Environment.NewLine + ex.Message);
             }
 
             fix.InstalledFix = installedFix;
 
-            var result = _installedFixesProvider.SaveInstalledFixes(_combinedEntitiesList);
+            var result = InstalledFixesProvider.SaveInstalledFixes(_combinedEntitiesList);
 
-            if (result.Item1)
+            if (result.IsSuccess)
             {
-                return new(true, "Fix updated successfully!");
+                return new(ResultEnum.Ok, "Fix updated successfully!");
             }
             else
             {
-                return new(false, result.Item2);
+                return new(ResultEnum.Error, result.Message);
             }
         }
     }

--- a/src/Common/Models/NewsModel.cs
+++ b/src/Common/Models/NewsModel.cs
@@ -37,7 +37,7 @@ namespace Common.Models
             }
             catch (Exception ex) when (ex is FileNotFoundException || ex is DirectoryNotFoundException)
             {
-                return new(ResultEnum.FileNotFound, "File not found: " + ex.Message);
+                return new(ResultEnum.NotFound, "File not found: " + ex.Message);
             }
             catch (Exception ex) when (ex is HttpRequestException || ex is TaskCanceledException)
             {

--- a/src/Common/Models/NewsModel.cs
+++ b/src/Common/Models/NewsModel.cs
@@ -1,5 +1,6 @@
 ﻿using Common.Config;
 using Common.Entities;
+using Common.Helpers;
 using Common.Providers;
 using System.Collections.Immutable;
 
@@ -28,7 +29,7 @@ namespace Common.Models
         /// <summary>
         /// Get list of news from online or local repo
         /// </summary>
-        public async Task<Tuple<bool, string>> UpdateNewsListAsync()
+        public async Task<Result> UpdateNewsListAsync()
         {
             try
             {
@@ -36,27 +37,27 @@ namespace Common.Models
             }
             catch (Exception ex) when (ex is FileNotFoundException || ex is DirectoryNotFoundException)
             {
-                return new(false, "File not found: " + ex.Message);
+                return new(ResultEnum.FileNotFound, "File not found: " + ex.Message);
             }
             catch (Exception ex) when (ex is HttpRequestException || ex is TaskCanceledException)
             {
-                return new(false, "Can't connect to GitHub repository");
+                return new(ResultEnum.ConnectionError, "Can't connect to GitHub repository");
             }
 
             UpdateReadStatusOfExistingNews();
 
-            return new(true, string.Empty);
+            return new(ResultEnum.Ok, string.Empty);
         }
 
         /// <summary>
         /// Mark all news as read
         /// </summary>
         /// <returns></returns>
-        public async Task<Tuple<bool, string>> MarkAllAsReadAsync()
+        public async Task<Result> MarkAllAsReadAsync()
         {
             var result = await UpdateNewsListAsync();
 
-            if (result.Item1)
+            if (result.IsSuccess)
             {
                 UpdateConfigLastReadVersion();
                 UpdateReadStatusOfExistingNews();

--- a/src/Common/Providers/CombinedEntitiesProvider.cs
+++ b/src/Common/Providers/CombinedEntitiesProvider.cs
@@ -8,17 +8,14 @@ namespace Common.Providers
     {
         private readonly FixesProvider _fixesProvider;
         private readonly GamesProvider _gamesProvider;
-        private readonly InstalledFixesProvider _installedFixesProvide;
 
         public CombinedEntitiesProvider(
             FixesProvider fixesProvider,
-            GamesProvider gamesProvider,
-            InstalledFixesProvider installedFixesProvider
+            GamesProvider gamesProvider
             )
         {
             _fixesProvider = fixesProvider ?? throw new NullReferenceException(nameof(fixesProvider));
             _gamesProvider = gamesProvider ?? throw new NullReferenceException(nameof(gamesProvider));
-            _installedFixesProvide = installedFixesProvider ?? throw new NullReferenceException(nameof(installedFixesProvider));
         }
         /// <summary>
         /// Get list of fix entities with installed fixes
@@ -66,7 +63,7 @@ namespace Common.Providers
                 games = await _gamesProvider.GetNewListAsync();
             }
 
-            installed = _installedFixesProvide.GetInstalledFixes();
+            installed = InstalledFixesProvider.GetInstalledFixes();
 
             List<FixFirstCombinedEntity> result = new();
 

--- a/src/Common/Providers/FixesProvider.cs
+++ b/src/Common/Providers/FixesProvider.cs
@@ -1,7 +1,6 @@
 ﻿using Common.Config;
 using Common.Entities;
 using Common.Helpers;
-using System;
 using System.Collections.Immutable;
 using System.Security.Cryptography;
 using System.Xml.Serialization;
@@ -191,12 +190,19 @@ namespace Common.Providers
             }
             catch (Exception e) when (e is FileNotFoundException || e is DirectoryNotFoundException)
             {
-                return new Result(ResultEnum.FileNotFound, e.Message);
+                return new Result(ResultEnum.NotFound, e.Message);
             }
 
             return new(ResultEnum.Ok, "XML saved successfully!");
         }
 
+        /// <summary>
+        /// Get MD5 of the local or online file
+        /// </summary>
+        /// <param name="client">Http client</param>
+        /// <param name="fix">Fix entity</param>
+        /// <returns>MD5 of the fix file</returns>
+        /// <exception cref="Exception">Http response error</exception>
         private static async Task<string> GetMD5(HttpClient client, FixEntity fix)
         {
             if (fix.Url is null) throw new NullReferenceException(nameof(fix.Url));

--- a/src/Common/Providers/FixesProvider.cs
+++ b/src/Common/Providers/FixesProvider.cs
@@ -78,7 +78,7 @@ namespace Common.Providers
         /// </summary>
         /// <param name="fixesList"></param>
         /// <returns></returns>
-        public async Task<Tuple<bool, string>> SaveFixesAsync(List<FixesList> fixesList)
+        public static async Task<Result> SaveFixesAsync(List<FixesList> fixesList)
         {
             using var client = new HttpClient();
 
@@ -99,9 +99,9 @@ namespace Common.Providers
                             {
                                 fix.MD5 = await GetMD5(client, fix);
                             }
-                            catch (Exception ex)
+                            catch (Exception e)
                             {
-
+                                return new Result(ResultEnum.ConnectionError, e.Message);
                             }
                         }
                     }
@@ -191,10 +191,10 @@ namespace Common.Providers
             }
             catch (Exception e) when (e is FileNotFoundException || e is DirectoryNotFoundException)
             {
-                return new Tuple<bool, string>(false, e.Message);
+                return new Result(ResultEnum.FileNotFound, e.Message);
             }
 
-            return new Tuple<bool, string>(true, "XML saved successfully!");
+            return new(ResultEnum.Ok, "XML saved successfully!");
         }
 
         private static async Task<string> GetMD5(HttpClient client, FixEntity fix)
@@ -221,7 +221,7 @@ namespace Common.Providers
 
                 if (!response.IsSuccessStatusCode)
                 {
-                    throw new Exception($"Error while getting response: {response.StatusCode}");
+                    throw new Exception($"Error while getting response for {fix.Url}: {response.StatusCode}");
                 }
                 else if (response.Content.Headers.ContentMD5 is not null)
                 {
@@ -285,7 +285,7 @@ namespace Common.Providers
         /// </summary>
         /// <param name="fixes">String to deserialize</param>
         /// <returns>List of fixes</returns>
-        private List<FixesList> DeserializeCachedString(string fixes)
+        private static List<FixesList> DeserializeCachedString(string fixes)
         {
             List<FixesList>? fixesDatabase;
 
@@ -308,7 +308,7 @@ namespace Common.Providers
         /// Download fixes xml from online repository
         /// </summary>
         /// <returns></returns>
-        private async Task<string> DownloadFixesXMLAsync()
+        private static async Task<string> DownloadFixesXMLAsync()
         {
             using (var client = new HttpClient())
             {

--- a/src/Common/Providers/InstalledFixesProvider.cs
+++ b/src/Common/Providers/InstalledFixesProvider.cs
@@ -6,13 +6,13 @@ using System.Xml.Serialization;
 
 namespace Common.Providers
 {
-    public sealed class InstalledFixesProvider
+    public static class InstalledFixesProvider
     {
         /// <summary>
         /// Remove current cache, then create new one and return installed fixes list
         /// </summary>
         /// <returns></returns>
-        public ImmutableList<InstalledFixEntity> GetInstalledFixes()
+        public static ImmutableList<InstalledFixEntity> GetInstalledFixes()
         {
             if (!File.Exists(Consts.InstalledFile))
             {
@@ -41,7 +41,7 @@ namespace Common.Providers
         /// </summary>
         /// <param name="combinedEntitiesList">List of combined entities</param>
         /// <returns>result, error message</returns>
-        public Tuple<bool, string> SaveInstalledFixes(List<FixFirstCombinedEntity> combinedEntitiesList)
+        public static Result SaveInstalledFixes(List<FixFirstCombinedEntity> combinedEntitiesList)
         {
             var installedFixes = CombinedEntitiesProvider.GetInstalledFixesFromCombined(combinedEntitiesList);
 
@@ -55,7 +55,7 @@ namespace Common.Providers
         /// </summary>
         /// <param name="fixesList">List of installed fix entities</param>
         /// <returns>result, error message</returns>
-        public Tuple<bool, string> SaveInstalledFixes(List<InstalledFixEntity> fixesList)
+        public static Result SaveInstalledFixes(List<InstalledFixEntity> fixesList)
         {
             XmlSerializer xmlSerializer = new(typeof(List<InstalledFixEntity>));
 
@@ -66,15 +66,15 @@ namespace Common.Providers
             }
             catch (Exception e) when (e is FileNotFoundException || e is DirectoryNotFoundException)
             {
-                return new Tuple<bool, string>(false, e.Message);
+                return new Result(ResultEnum.FileNotFound, e.Message);
             }
 
-            return new Tuple<bool, string>(true, string.Empty);
+            return new (ResultEnum.Ok, string.Empty);
         }
 
         /// <summary>
         /// Create empty installed fixes XML
         /// </summary>
-        private void MakeEmptyFixesXml() => SaveInstalledFixes(new List<InstalledFixEntity>());
+        private static void MakeEmptyFixesXml() => SaveInstalledFixes(new List<InstalledFixEntity>());
     }
 }

--- a/src/Common/Providers/InstalledFixesProvider.cs
+++ b/src/Common/Providers/InstalledFixesProvider.cs
@@ -66,7 +66,7 @@ namespace Common.Providers
             }
             catch (Exception e) when (e is FileNotFoundException || e is DirectoryNotFoundException)
             {
-                return new Result(ResultEnum.FileNotFound, e.Message);
+                return new Result(ResultEnum.NotFound, e.Message);
             }
 
             return new (ResultEnum.Ok, string.Empty);

--- a/src/Common/UpdateInstaller.cs
+++ b/src/Common/UpdateInstaller.cs
@@ -43,7 +43,7 @@ namespace Common
                 File.Delete(fileName);
             }
 
-            await FileTools.DownloadFileAsync(fixUrl, fileName);
+            await FileTools.CheckAndDownloadFileAsync(fixUrl, fileName);
 
             ZipFile.ExtractToDirectory(fileName, Path.Combine(Directory.GetCurrentDirectory(), Consts.UpdateFolder), true);
 

--- a/src/Tests/SyncTests.cs
+++ b/src/Tests/SyncTests.cs
@@ -9,7 +9,7 @@ using System.Security.Cryptography;
 namespace Tests
 {
     /// <summary>
-    /// Tests that use instance data and should be run in single thread
+    /// Tests that use instance data and should be run in a single thread
     /// </summary>
     [TestClass]
     public sealed class SyncTests
@@ -102,7 +102,7 @@ namespace Tests
 
             try
             {
-                await fixInstaller.InstallFix(gameEntity, fixEntity, null);
+                await fixInstaller.InstallFix(gameEntity, fixEntity, null, false);
             }
             catch (HashCheckFailedException)
             {
@@ -137,7 +137,7 @@ namespace Tests
 
             var fixInstaller = BindingsManager.Instance.GetInstance<FixInstaller>();
 
-            var installedFix = await fixInstaller.InstallFix(gameEntity, fixEntity, null);
+            var installedFix = await fixInstaller.InstallFix(gameEntity, fixEntity, null, true);
 
             InstalledFixesProvider.SaveInstalledFixes(new List<InstalledFixEntity>() { installedFix });
 
@@ -186,7 +186,7 @@ namespace Tests
 
             var fixInstaller = BindingsManager.Instance.GetInstance<FixInstaller>();
 
-            var installedFix = await fixInstaller.InstallFix(gameEntity, fixEntity, variant);
+            var installedFix = await fixInstaller.InstallFix(gameEntity, fixEntity, variant, true);
 
             InstalledFixesProvider.SaveInstalledFixes(new List<InstalledFixEntity>() { installedFix });
 

--- a/src/Tests/SyncTests.cs
+++ b/src/Tests/SyncTests.cs
@@ -106,6 +106,7 @@ namespace Tests
             }
             catch (HashCheckFailedException)
             {
+                //method failed successfully
                 return;
             }
 
@@ -135,19 +136,17 @@ namespace Tests
             };
 
             var fixInstaller = BindingsManager.Instance.GetInstance<FixInstaller>();
-            var fixUninstaller = BindingsManager.Instance.GetInstance<FixUninstaller>();
-            var installedProvider = BindingsManager.Instance.GetInstance<InstalledFixesProvider>();
 
             var installedFix = await fixInstaller.InstallFix(gameEntity, fixEntity, null);
 
-            installedProvider.SaveInstalledFixes(new List<InstalledFixEntity>() { installedFix });
+            InstalledFixesProvider.SaveInstalledFixes(new List<InstalledFixEntity>() { installedFix });
 
             var exeExists = File.Exists("game\\new folder\\start game.exe");
             Assert.IsTrue(exeExists);
 
             fixEntity.InstalledFix = installedFix;
 
-            fixUninstaller.UninstallFix(gameEntity, installedFix);
+            FixUninstaller.UninstallFix(gameEntity, installedFix);
 
             var newDirExists = Directory.Exists("game\\new folder");
             Assert.IsFalse(newDirExists);
@@ -186,12 +185,10 @@ namespace Tests
             };
 
             var fixInstaller = BindingsManager.Instance.GetInstance<FixInstaller>();
-            var fixUninstaller = BindingsManager.Instance.GetInstance<FixUninstaller>();
-            var installedProvider = BindingsManager.Instance.GetInstance<InstalledFixesProvider>();
 
             var installedFix = await fixInstaller.InstallFix(gameEntity, fixEntity, variant);
 
-            installedProvider.SaveInstalledFixes(new List<InstalledFixEntity>() { installedFix });
+            InstalledFixesProvider.SaveInstalledFixes(new List<InstalledFixEntity>() { installedFix });
 
             CheckNewFiles();
 
@@ -200,7 +197,7 @@ namespace Tests
             //modify backed up file
             File.WriteAllText("game\\install folder\\file to backup.txt", "22");
 
-            fixUninstaller.UninstallFix(gameEntity, installedFix);
+            FixUninstaller.UninstallFix(gameEntity, installedFix);
 
             CheckOriginalFiles();
         }

--- a/src/Tests/SyncTests.cs
+++ b/src/Tests/SyncTests.cs
@@ -127,6 +127,7 @@ namespace Tests
         private static async Task InstallUninstallFixAsync(string? variant)
         {
             string fixArchive = variant is null ? "test_fix.zip" : "test_fix_variant.zip";
+            string fixArchiveMD5 = variant is null ? "4E9DE15FC40592B26421E05882C2F6F7" : "DA2D7701D2EB5BC9A35FB58B3B04C5B9";
 
             string gameFolder = PrepareGameFolder();
 
@@ -146,7 +147,8 @@ namespace Tests
                 Url = "test_fix.zip",
                 InstallFolder = "install folder",
                 FilesToDelete = new() { "install folder\\file to delete.txt", "install folder\\subfolder\\file to delete in subfolder.txt", "file to delete in parent folder.txt" },
-                FilesToBackup = new() { "install folder\\file to backup.txt" }
+                FilesToBackup = new() { "install folder\\file to backup.txt" },
+                MD5 = fixArchiveMD5
             };
 
             var fixInstaller = BindingsManager.Instance.GetInstance<FixInstaller>();

--- a/src/WPF/Superheater/MainWindow.xaml.cs
+++ b/src/WPF/Superheater/MainWindow.xaml.cs
@@ -31,7 +31,7 @@ namespace Superheater
 
             InitializeComponent();
 
-            void OnDispatcherUnhandledException(object sender, System.Windows.Threading.DispatcherUnhandledExceptionEventArgs e)
+            static void OnDispatcherUnhandledException(object sender, System.Windows.Threading.DispatcherUnhandledExceptionEventArgs e)
             {
                 string errorMessage = $"An unhandled exception occurred:{Environment.NewLine}{e.Exception.Message}";
 

--- a/src/WPF/Superheater/ViewModels/EditorViewModel.cs
+++ b/src/WPF/Superheater/ViewModels/EditorViewModel.cs
@@ -35,7 +35,7 @@ namespace Superheater.ViewModels
         private readonly FixesProvider _fixesProvider;
         private readonly SemaphoreSlim _locker = new(1, 1);
 
-        public bool IsDeveloperMode => true;
+        public static bool IsDeveloperMode => true;
 
         public ImmutableList<FixesList> FilteredGamesList => _editorModel.GetFilteredGamesList(Search);
 
@@ -207,7 +207,7 @@ namespace Superheater.ViewModels
         {
             if (SelectedGame is null) throw new NullReferenceException(nameof(SelectedGame));
 
-            var newFix = _editorModel.AddNewFix(SelectedGame);
+            var newFix = EditorModel.AddNewFix(SelectedGame);
 
             OnPropertyChanged(nameof(SelectedGameFixes));
 
@@ -225,7 +225,7 @@ namespace Superheater.ViewModels
             if (SelectedGame is null) throw new NullReferenceException(nameof(SelectedGame));
             if (SelectedFix is null) throw new NullReferenceException(nameof(SelectedFix));
 
-            _editorModel.RemoveFix(SelectedGame, SelectedFix);
+            EditorModel.RemoveFix(SelectedGame, SelectedFix);
 
             OnPropertyChanged(nameof(SelectedGameFixes));
         }
@@ -244,13 +244,13 @@ namespace Superheater.ViewModels
         /// Save fixes.xml
         /// </summary>
         [RelayCommand]
-        private void SaveChanges()
+        private async Task SaveChangesAsync()
         {
-            var result = _editorModel.SaveFixesListAsync();
+            var result = await _editorModel.SaveFixesListAsync();
 
             MessageBox.Show(
-                result.Item2,
-                result.Item1 ? "Success" : "Error",
+                result.Message,
+                result.IsSuccess ? "Success" : "Error",
                 MessageBoxButton.OK
                 );
         }
@@ -276,7 +276,7 @@ namespace Superheater.ViewModels
         {
             if (SelectedFix is null) throw new NullReferenceException(nameof(SelectedFix));
 
-            _editorModel.AddDependencyForFix(SelectedFix, AvailableDependencies.ElementAt(SelectedAvailableDependencyIndex));
+            EditorModel.AddDependencyForFix(SelectedFix, AvailableDependencies.ElementAt(SelectedAvailableDependencyIndex));
 
             OnPropertyChanged(nameof(AvailableDependencies));
             OnPropertyChanged(nameof(AddedDependencies));
@@ -292,7 +292,7 @@ namespace Superheater.ViewModels
         {
             if (SelectedFix is null) throw new NullReferenceException(nameof(SelectedFix));
 
-            _editorModel.RemoveDependencyForFix(SelectedFix, AddedDependencies.ElementAt(SelectedAddedDependencyIndex));
+            EditorModel.RemoveDependencyForFix(SelectedFix, AddedDependencies.ElementAt(SelectedAddedDependencyIndex));
 
             OnPropertyChanged(nameof(AvailableDependencies));
             OnPropertyChanged(nameof(AddedDependencies));
@@ -326,7 +326,7 @@ namespace Superheater.ViewModels
         {
             if (SelectedGame is null) throw new NullReferenceException(nameof(SelectedGame));
 
-            _editorModel.MoveFixUp(SelectedGame.Fixes, SelectedFixIndex);
+            EditorModel.MoveFixUp(SelectedGame.Fixes, SelectedFixIndex);
 
             OnPropertyChanged(nameof(SelectedGameFixes));
             MoveFixDownCommand.NotifyCanExecuteChanged();
@@ -343,7 +343,7 @@ namespace Superheater.ViewModels
         {
             if (SelectedGame is null) throw new NullReferenceException(nameof(SelectedGame));
 
-            _editorModel.MoveFixDown(SelectedGame.Fixes, SelectedFixIndex);
+            EditorModel.MoveFixDown(SelectedGame.Fixes, SelectedFixIndex);
 
             OnPropertyChanged(nameof(SelectedGameFixes));
             MoveFixDownCommand.NotifyCanExecuteChanged();
@@ -362,10 +362,10 @@ namespace Superheater.ViewModels
 
             var canUpload = await _editorModel.CheckFixBeforeUploadAsync(SelectedFix);
 
-            if (!canUpload.Item1)
+            if (!canUpload.IsSuccess)
             {
                 MessageBox.Show(
-                    canUpload.Item2,
+                    canUpload.Message,
                     "Error",
                     MessageBoxButton.OK
                     );
@@ -376,11 +376,11 @@ namespace Superheater.ViewModels
             var fixesList = SelectedGame ?? throw new NullReferenceException(nameof(SelectedFix));
             var fix = SelectedFix ?? throw new NullReferenceException(nameof(SelectedFix));
 
-            var result = _editorModel.UploadFix(fixesList, fix);
+            var result = EditorModel.UploadFix(fixesList, fix);
 
             MessageBox.Show(
-                result.Item2,
-                result.Item1 ? "Success" : "Error",
+                result.Message,
+                result.IsSuccess ? "Success" : "Error",
                 MessageBoxButton.OK
                 );
         }
@@ -429,10 +429,10 @@ namespace Superheater.ViewModels
 
             FillGamesList();
 
-            if (!result.Item1)
+            if (!result.IsSuccess)
             {
                 MessageBox.Show(
-                    result.Item2,
+                    result.Message,
                     "Error",
                     MessageBoxButton.OK
                     );

--- a/src/WPF/Superheater/ViewModels/MainViewModel.cs
+++ b/src/WPF/Superheater/ViewModels/MainViewModel.cs
@@ -41,7 +41,7 @@ namespace Superheater.ViewModels
 
         public string LaunchGameButtonText { get; private set; }
 
-        public bool IsSteamGameMode => CommonProperties.IsInSteamDeckGameMode;
+        public static bool IsSteamGameMode => CommonProperties.IsInSteamDeckGameMode;
 
         /// <summary>
         /// Does selected fix has variants
@@ -167,10 +167,10 @@ namespace Superheater.ViewModels
             ProgressBarValue = 0;
             OnPropertyChanged(nameof(ProgressBarValue));
 
-            if (!result.Item1)
+            if (!result.IsSuccess)
             {
                 MessageBox.Show(
-                    result.Item2,
+                    result.Message,
                     "Error",
                     MessageBoxButton.OK
                     );
@@ -182,7 +182,7 @@ namespace Superheater.ViewModels
                 _config.OpenConfigAfterInstall)
             {
                 MessageBox.Show(
-                    result.Item2,
+                    result.Message,
                     "Success",
                     MessageBoxButton.OK
                     );
@@ -190,7 +190,7 @@ namespace Superheater.ViewModels
             else
             {
                 MessageBox.Show(
-                    result.Item2,
+                    result.Message,
                     "Success",
                     MessageBoxButton.OK
                     );
@@ -238,8 +238,8 @@ namespace Superheater.ViewModels
             UpdateGamesCommand.NotifyCanExecuteChanged();
 
             MessageBox.Show(
-                result.Item2,
-                result.Item1 ? "Success" : "Error",
+                result.Message,
+                result.IsSuccess ? "Success" : "Error",
                 MessageBoxButton.OK
                 );
         }
@@ -254,7 +254,7 @@ namespace Superheater.ViewModels
                 return false;
             }
 
-            var result = !_mainModel.DoesFixHaveInstalledDependentFixes(SelectedGameFixesList, SelectedFix.Guid);
+            var result = !MainModel.DoesFixHaveInstalledDependentFixes(SelectedGameFixesList, SelectedFix.Guid);
 
             return result;
         }
@@ -290,12 +290,12 @@ namespace Superheater.ViewModels
             UpdateGamesCommand.NotifyCanExecuteChanged();
 
             MessageBox.Show(
-                result.Item2,
-                result.Item1 ? "Success" : "Error",
+                result.Message,
+                result.IsSuccess ? "Success" : "Error",
                 MessageBoxButton.OK
                 );
 
-            if (result.Item1 &&
+            if (result.IsSuccess &&
                 selectedFix.ConfigFile is not null &&
                 _config.OpenConfigAfterInstall)
             {
@@ -432,7 +432,7 @@ namespace Superheater.ViewModels
         /// Close app
         /// </summary>
         [RelayCommand]
-        private void CloseApp() => Environment.Exit(0);
+        private static void CloseApp() => Environment.Exit(0);
 
         #endregion Relay Commands
 
@@ -449,11 +449,11 @@ namespace Superheater.ViewModels
 
             FillGamesList();
 
-            if (!result.Item1)
+            if (!result.IsSuccess)
             {
 
                 MessageBox.Show(
-                    result.Item2,
+                    result.Message,
                     "Error",
                     MessageBoxButton.OK
                     );
@@ -592,7 +592,7 @@ Do you want to set it to always run as admin?",
 
             if (SelectedFix?.Dependencies is not null)
             {
-                var dependsBy = _mainModel.GetDependentFixes(SelectedGameFixesList, SelectedFix.Guid);
+                var dependsBy = MainModel.GetDependentFixes(SelectedGameFixesList, SelectedFix.Guid);
 
                 if (dependsBy.Any())
                 {

--- a/src/WPF/Superheater/ViewModels/MainViewModel.cs
+++ b/src/WPF/Superheater/ViewModels/MainViewModel.cs
@@ -153,7 +153,7 @@ namespace Superheater.ViewModels
 
             FileTools.Progress.ProgressChanged += Progress_ProgressChanged;
 
-            var result = await _mainModel.InstallFix(SelectedGame.Game, SelectedFix, SelectedFixVariant);
+            var result = await _mainModel.InstallFix(SelectedGame.Game, SelectedFix, SelectedFixVariant, true);
 
             FillGamesList();
 
@@ -278,7 +278,7 @@ namespace Superheater.ViewModels
 
             var selectedFix = SelectedFix;
 
-            var result = await _mainModel.UpdateFix(SelectedGame.Game, SelectedFix, SelectedFixVariant);
+            var result = await _mainModel.UpdateFix(SelectedGame.Game, SelectedFix, SelectedFixVariant, true);
 
             FillGamesList();
 

--- a/src/WPF/Superheater/ViewModels/NewsViewModel.cs
+++ b/src/WPF/Superheater/ViewModels/NewsViewModel.cs
@@ -39,10 +39,10 @@ namespace Superheater.ViewModels
         {
             var result = await _newsModel.MarkAllAsReadAsync();
 
-            if (!result.Item1)
+            if (!result.IsSuccess)
             {
                 MessageBox.Show(
-                    result.Item2,
+                    result.Message,
                     "Error",
                     MessageBoxButton.OK
                     );
@@ -61,10 +61,10 @@ namespace Superheater.ViewModels
         {
             var result = await _newsModel.UpdateNewsListAsync();
 
-            if (!result.Item1)
+            if (!result.IsSuccess)
             {
                 MessageBox.Show(
-                    result.Item2,
+                    result.Message,
                     "Error",
                     MessageBoxButton.OK
                     );


### PR DESCRIPTION
Fix entity now contains MD5 hash of the fix's zip. If during fix install it doesn't match with the downloaded file's hash, the warning will be shown.

![image](https://github.com/fgsfds/Steam-Superheater/assets/4870330/6e35ed24-9ab2-4975-94d9-6ca8506fcb5a)
